### PR TITLE
Fixed bugs

### DIFF
--- a/search/backend/main.py
+++ b/search/backend/main.py
@@ -289,8 +289,6 @@ def rerank():
     query = request.json['query']
     results = request.json['results']
     
-    print(f'{query = }')
-    
     reranker = CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2', default_activation_function=torch.nn.Sigmoid())
     rerank_inputs = []
     for result in results:

--- a/search/frontend/app.py
+++ b/search/frontend/app.py
@@ -186,7 +186,7 @@ def main():
                 'OpenAI': [
                     'text-embedding-ada-002',
                     'text-embedding-3-small',
-                    'text-embedding-3-large',
+                    # 'text-embedding-3-large', # Not supported by CosmosDB - capped to vector of length 2000 only
                     'Other Model'
                 ]
             }


### PR DESCRIPTION
- Removed extraneous print statements
- Deprecated OpenAI's `text-embedding-3-large` model for the time being
    - Azure CosmosDB for MongoDB does not support support vectors of size > 2000; thus, the solution currently cannot use models that generate embeddings of size > 2000
    - To allow use of such models, either switch to CosmosDB for NoSQL or PostgreSQL, or migrate to a suitable alternative of CosmosDB